### PR TITLE
Fix undefined variable error

### DIFF
--- a/src/imagely.es6
+++ b/src/imagely.es6
@@ -140,7 +140,10 @@ class Imagely {
 			})
 			.catch((err) => {
 				if (this.callback) {
-					this.callback('Error rendering file "' + filepath + '": ' + err)
+					this.callback(err);
+				}
+				else {
+					throw err;
 				}
 			});
 	}


### PR DESCRIPTION
'filepath' is not defined within the lexical scope, so the caught error is never propagated correctly.